### PR TITLE
gitignore, typos, fromatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.o
+*.ko
+*cmd
+*.swp
+*mod*
+*.symvers

--- a/3.16/LKMPG-3.16.html
+++ b/3.16/LKMPG-3.16.html
@@ -485,7 +485,7 @@ The source code and discussions should apply to most architectures, but I can't 
 <h3 id="orge62c760">Acknowledgements</h3>
 <div class="outline-text-3" id="text-orge62c760">
 <p>
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 </p>
 </div>
 </div>
@@ -1430,13 +1430,17 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 <div class="org-src-container">
 <pre class="src src-c"><span class="org-preprocessor">#include</span> <span class="org-string">&lt;stdio.h&gt;</span>
+
 <span class="org-type">int</span> <span class="org-function-name">main</span>(<span class="org-type">void</span>)
-{ printf(<span class="org-string">"hello"</span>); <span class="org-keyword">return</span> 0; }
+{
+    printf(<span class="org-string">"hello"</span>);
+    <span class="org-keyword">return</span> 0;
+}
 </pre>
 </div>
 
 <p>
-with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with strace <b>./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with <b>strace ./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 </p>
 
 <p>

--- a/3.16/LKMPG-3.16.org
+++ b/3.16/LKMPG-3.16.org
@@ -27,7 +27,7 @@ The source code and discussions should apply to most architectures, but I can't 
 
 ** Acknowledgements
 
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 
 ** What Is A Kernel Module?
 
@@ -667,11 +667,15 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 #+BEGIN_SRC c
 #include <stdio.h>
+
 int main(void)
-{ printf("hello"); return 0; }
+{
+    printf("hello");
+    return 0;
+}
 #+END_SRC
 
-with *gcc -Wall -o hello hello.c*. Run the exectable with strace *./hello*. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with *gcc -Wall -o hello hello.c*. Run the exectable with *strace ./hello*. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 
 You can even write modules to replace the kernel's system calls, which we'll do shortly. Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel write Tee hee, that tickles! everytime someone tries to delete a file on your system.
 

--- a/3.8/LKMPG-3.8.html
+++ b/3.8/LKMPG-3.8.html
@@ -483,7 +483,7 @@ The source code and discussions should apply to most architectures, but I can't 
 </p>
 
 <p>
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 </p>
 
 <div id="outline-container-orgf7edacc" class="outline-2">
@@ -1616,7 +1616,10 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 #+BEGIN_SRC: c
 #include &lt;stdio.h&gt;
 int main(void)
-{ printf("hello"); return 0; }
+{
+    printf("hello");
+    return 0;
+}
 #+END_SRC
 </p>
 

--- a/3.8/LKMPG-3.8.org
+++ b/3.8/LKMPG-3.8.org
@@ -29,7 +29,7 @@ The source code and discussions should apply to most architectures, but I can't 
 
 *Acknowledgements*
 
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 
 * Introduction
 ** What Is A Kernel Module?
@@ -714,11 +714,15 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 #+BEGIN_SRC: c
 #include <stdio.h>
+
 int main(void)
-{ printf("hello"); return 0; }
+{
+    printf("hello");
+    return 0;
+}
 #+END_SRC
 
-with gcc -Wall -o hello hello.c. Run the exectable with strace ./hello. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with gcc -Wall -o hello hello.c. Run the exectable with strace ./hello. Are you impressed? Every line you see corresponds to a system call. strace[4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 
 You can even write modules to replace the kernel's system calls, which we'll do shortly. Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel write Tee hee, that tickles! everytime someone tries to delete a file on your system.
 

--- a/4.7.4/LKMPG-4.7.4.html
+++ b/4.7.4/LKMPG-4.7.4.html
@@ -395,7 +395,7 @@ The source code and discussions should apply to most architectures, but I can't 
 <h3 id="org5bd09c1">Acknowledgements</h3>
 <div class="outline-text-3" id="text-org5bd09c1">
 <p>
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 </p>
 </div>
 </div>
@@ -1250,13 +1250,17 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 <div class="org-src-container">
 <pre class="src src-c"><span class="org-preprocessor">#include</span> <span class="org-string">&lt;stdio.h&gt;</span>
+
 <span class="org-type">int</span> <span class="org-function-name">main</span>(<span class="org-type">void</span>)
-{ printf(<span class="org-string">"hello"</span>); <span class="org-keyword">return</span> 0; }
+{
+    printf(<span class="org-string">"hello"</span>);
+    <span class="org-keyword">return</span> 0;
+}
 </pre>
 </div>
 
 <p>
-with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with strace <b>./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with <b>strace ./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 </p>
 
 <p>

--- a/4.7.4/LKMPG-4.7.4.org
+++ b/4.7.4/LKMPG-4.7.4.org
@@ -27,7 +27,7 @@ The source code and discussions should apply to most architectures, but I can't 
 
 ** Acknowledgements
 
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 
 ** What Is A Kernel Module?
 
@@ -618,11 +618,15 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 #+BEGIN_SRC c
 #include <stdio.h>
+
 int main(void)
-{ printf("hello"); return 0; }
+{
+    printf("hello");
+    return 0;
+}
 #+END_SRC
 
-with *gcc -Wall -o hello hello.c*. Run the exectable with strace *./hello*. Are you impressed? Every line you see corresponds to a system call. strace[fn:4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with *gcc -Wall -o hello hello.c*. Run the exectable with *strace ./hello*. Are you impressed? Every line you see corresponds to a system call. strace[fn:4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 
 You can even write modules to replace the kernel's system calls, which we'll do shortly. Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel write Tee hee, that tickles! everytime someone tries to delete a file on your system.
 

--- a/4.9.11/LKMPG-4.9.11.html
+++ b/4.9.11/LKMPG-4.9.11.html
@@ -395,7 +395,7 @@ The source code and discussions should apply to most architectures, but I can't 
 <h3 id="org7999c24">Acknowledgements</h3>
 <div class="outline-text-3" id="text-org7999c24">
 <p>
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 </p>
 </div>
 </div>
@@ -1264,13 +1264,17 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 <div class="org-src-container">
 <pre class="src src-c"><span class="org-preprocessor">#include</span> <span class="org-string">&lt;stdio.h&gt;</span>
+
 <span class="org-type">int</span> <span class="org-function-name">main</span>(<span class="org-type">void</span>)
-{ printf(<span class="org-string">"hello"</span>); <span class="org-keyword">return</span> 0; }
+{
+    printf(<span class="org-string">"hello"</span>);
+    <span class="org-keyword">return</span> 0;
+}
 </pre>
 </div>
 
 <p>
-with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with strace <b>./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with <b>gcc -Wall -o hello hello.c</b>. Run the exectable with <b>strace ./hello</b>. Are you impressed? Every line you see corresponds to a system call. strace<sup><a id="fnr.1" class="footref" href="#fn.1">1</a></sup> is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 </p>
 
 <p>

--- a/4.9.11/LKMPG-4.9.11.org
+++ b/4.9.11/LKMPG-4.9.11.org
@@ -27,7 +27,7 @@ The source code and discussions should apply to most architectures, but I can't 
 
 ** Acknowledgements
 
-The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier and Bob Mottram.
+The following people have contributed corrections or good suggestions: Ignacio Martin, David Porter, Daniele Paolo Scarpazza, Dimo Velev, Francois Audeon, Horst Schirmeier, Bob Mottram and Roman Lakeev.
 
 ** What Is A Kernel Module?
 
@@ -618,11 +618,15 @@ Would you like to see what system calls are made by printf()? It's easy! Compile
 
 #+BEGIN_SRC c
 #include <stdio.h>
+
 int main(void)
-{ printf("hello"); return 0; }
+{
+    printf("hello");
+    return 0;
+}
 #+END_SRC
 
-with *gcc -Wall -o hello hello.c*. Run the exectable with strace *./hello*. Are you impressed? Every line you see corresponds to a system call. strace[fn:4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read (). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
+with *gcc -Wall -o hello hello.c*. Run the exectable with *strace ./hello*. Are you impressed? Every line you see corresponds to a system call. strace[fn:4] is a handy program that gives you details about what system calls a program is making, including which call is made, what its arguments are and what it returns. It's an invaluable tool for figuring out things like what files a program is trying to access. Towards the end, you'll see a line which looks like write (1, "hello", 5hello). There it is. The face behind the printf() mask. You may not be familiar with write, since most people use library functions for file I/O (like fopen, fputs, fclose). If that's the case, try looking at man 2 write. The 2nd man section is devoted to system calls (like kill() and read()). The 3rd man section is devoted to library calls, which you would probably be more familiar with (like cosh() and random()).
 
 You can even write modules to replace the kernel's system calls, which we'll do shortly. Crackers often make use of this sort of thing for backdoors or trojans, but you can write your own modules to do more benign things, like have the kernel write Tee hee, that tickles! everytime someone tries to delete a file on your system.
 


### PR DESCRIPTION
Hi! I continued to read this great  book and I think that following changes are useful:

- adding gitignore for ignoring examples build artefacts
- change formatting of example in 'Functions available to modules' section
- minor typos correction in 'Functions available to modules' section
- adding my name to 'Acknowledgements'